### PR TITLE
Add deploy-choon command to share your songs with a wider audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ Queues the best match based on the title or artist provided.
 
 Queues a specific Spotify track.
 
+### broadcast `song title` by `artist`
+
+Queues the matched song based on the title and artist provided in all locations.
+
+### broadcast `song title or artist`
+
+Queues the best match based on the title or artist provided in all locations.
+
+### broadcast `spotify:track:spotify-track-uuid`
+
+Queues a specific Spotify track in all locations.
+
 ### pause(, in `location`)
 
 Pauses currently playing song.

--- a/src/commands/broadcast-song/index.js
+++ b/src/commands/broadcast-song/index.js
@@ -28,43 +28,43 @@ const init = function(listen, library, locations) {
    * eg. @djroomba broadcast Under the Bridge by Red Hot Chili Peppers
    * eg. @djroomba broadcast "Me and Julio down by the schoolyard" by "Paul Simon"
    */
-  const queueSpecificSong =
+  const broadcastSpecificSong =
     '(dry run )?broadcast "?([^"]+)"? by "?([^"]+?)"?';
   multiLocationSpecificSong(
     listen,
     library,
     locations,
     displaySongChoice,
-    queueSpecificSong,
+    broadcastSpecificSong,
     "queue"
   );
 
   /*
-   * Spotify track search command, to queue song
+   * Spotify track search command, to queue song.  Queues the song in ALL locations.
    * eg. @djroomba broadcast spotify:track:3d9DChrdc6BOeFsbrZ3Is0
    */
-  const queueSpotifySong =
+  const broadcastSpotifySong =
     "(dry run )?broadcast ['`\"]?<spotify:track:([^>]+)>['`\"]?";
   multiLocationSpotifySong(
     listen,
     library,
     locations,
     displaySongChoice,
-    queueSpotifySong,
+    broadcastSpotifySong,
     "queue"
   );
 
   /*
-   * Wildcard track search command, to queue song
+   * Wildcard track search command, to queue song in ALL locations.
    * eg. @djroomba broadcast Under the Bridge
    */
-  const queueWildcardSong = "(dry run )?queue (.+?)";
+  const broadcastWildcardSong = "(dry run )?broadcast (.+?)";
   multiLocationWildcardSong(
     listen,
     library,
     locations,
     displaySongChoice,
-    queueWildcardSong,
+    broadcastWildcardSong,
     "queue"
   );
 };

--- a/src/commands/broadcast-song/index.js
+++ b/src/commands/broadcast-song/index.js
@@ -25,11 +25,11 @@ const displaySongChoice = async function(
 const init = function(listen, library, locations) {
   /*
    * Specific track search command, to queue song.  Queues the song in ALL locations.
-   * eg. @djroomba deploy-choon Under the Bridge by Red Hot Chili Peppers
-   * eg. @djroomba deploy-choon "Me and Julio down by the schoolyard" by "Paul Simon"
+   * eg. @djroomba broadcast Under the Bridge by Red Hot Chili Peppers
+   * eg. @djroomba broadcast "Me and Julio down by the schoolyard" by "Paul Simon"
    */
   const queueSpecificSong =
-    '(dry run )?deploy-choon "?([^"]+)"? by "?([^"]+?)"?';
+    '(dry run )?broadcast "?([^"]+)"? by "?([^"]+?)"?';
   multiLocationSpecificSong(
     listen,
     library,
@@ -41,10 +41,10 @@ const init = function(listen, library, locations) {
 
   /*
    * Spotify track search command, to queue song
-   * eg. @djroomba deploy-choon spotify:track:3d9DChrdc6BOeFsbrZ3Is0
+   * eg. @djroomba broadcast spotify:track:3d9DChrdc6BOeFsbrZ3Is0
    */
   const queueSpotifySong =
-    "(dry run )?deploy-choon ['`\"]?<spotify:track:([^>]+)>['`\"]?";
+    "(dry run )?broadcast ['`\"]?<spotify:track:([^>]+)>['`\"]?";
   multiLocationSpotifySong(
     listen,
     library,
@@ -56,7 +56,7 @@ const init = function(listen, library, locations) {
 
   /*
    * Wildcard track search command, to queue song
-   * eg. @djroomba deploy-choon Under the Bridge
+   * eg. @djroomba broadcast Under the Bridge
    */
   const queueWildcardSong = "(dry run )?queue (.+?)";
   multiLocationWildcardSong(

--- a/src/commands/deploy-choon/index.js
+++ b/src/commands/deploy-choon/index.js
@@ -1,0 +1,72 @@
+const multiLocationSpecificSong = require("../multi-location-specific-song");
+const multiLocationSpotifySong = require("../multi-location-spotify-song");
+const multiLocationWildcardSong = require("../multi-location-wildcard-song");
+
+const displaySongChoice = async function(
+  bot,
+  updateMessage,
+  message,
+  { artist, name },
+  isDryRun,
+  locationName
+) {
+  const dryRunPrefix = isDryRun
+    ? "if this hadn't been a dry run :beach_with_umbrella: I'd have "
+    : "";
+
+  await updateMessage(
+    `Thanks <@${message.user}>, ` +
+      dryRunPrefix +
+      `queued "${name}" by ${artist} :man-with-bunny-ears-partying:,` +
+      ` in ${locationName}:round_pushpin:`
+  );
+};
+
+const init = function(listen, library, locations) {
+  /*
+   * Specific track search command, to queue song.  Queues the song in ALL locations.
+   * eg. @djroomba deploy-choon Under the Bridge by Red Hot Chili Peppers
+   * eg. @djroomba deploy-choon "Me and Julio down by the schoolyard" by "Paul Simon"
+   */
+  const queueSpecificSong =
+    '(dry run )?deploy-choon "?([^"]+)"? by "?([^"]+?)"?';
+  multiLocationSpecificSong(
+    listen,
+    library,
+    locations,
+    displaySongChoice,
+    queueSpecificSong,
+    "queue"
+  );
+
+  /*
+   * Spotify track search command, to queue song
+   * eg. @djroomba deploy-choon spotify:track:3d9DChrdc6BOeFsbrZ3Is0
+   */
+  const queueSpotifySong =
+    "(dry run )?deploy-choon ['`\"]?<spotify:track:([^>]+)>['`\"]?";
+  multiLocationSpotifySong(
+    listen,
+    library,
+    locations,
+    displaySongChoice,
+    queueSpotifySong,
+    "queue"
+  );
+
+  /*
+   * Wildcard track search command, to queue song
+   * eg. @djroomba deploy-choon Under the Bridge
+   */
+  const queueWildcardSong = "(dry run )?queue (.+?)";
+  multiLocationWildcardSong(
+    listen,
+    library,
+    locations,
+    displaySongChoice,
+    queueWildcardSong,
+    "queue"
+  );
+};
+
+module.exports = init;

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -2,7 +2,7 @@ const initPlaySongCommands = require("./play-song");
 const initQueueSongCommands = require("./queue-song");
 const initPauseSongCommands = require("./pause-song");
 const initViewSongsCommands = require("./view-songs");
-const initDeployChoonCommands = require("./deploy-choon");
+const initBroadcastSongCommands = require("./broadcast-song");
 
 const init = function({ listen }, library, locations) {
   logger.debug("Setting up commands");
@@ -11,7 +11,7 @@ const init = function({ listen }, library, locations) {
   initQueueSongCommands(listen, library, locations);
   initPauseSongCommands(listen, library, locations);
   initViewSongsCommands(listen, library, locations);
-  initDeployChoonCommands(listen, library, locations);
+  initBroadcastSongCommands(listen, library, locations);
 };
 
 module.exports = init;

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -2,6 +2,7 @@ const initPlaySongCommands = require("./play-song");
 const initQueueSongCommands = require("./queue-song");
 const initPauseSongCommands = require("./pause-song");
 const initViewSongsCommands = require("./view-songs");
+const initDeployChoonCommands = require("./deploy-choon");
 
 const init = function({ listen }, library, locations) {
   logger.debug("Setting up commands");
@@ -10,6 +11,7 @@ const init = function({ listen }, library, locations) {
   initQueueSongCommands(listen, library, locations);
   initPauseSongCommands(listen, library, locations);
   initViewSongsCommands(listen, library, locations);
+  initDeployChoonCommands(listen, library, locations);
 };
 
 module.exports = init;

--- a/src/commands/multi-location-specific-song/index.js
+++ b/src/commands/multi-location-specific-song/index.js
@@ -1,3 +1,4 @@
+const _ = require("lodash");
 const { actOnSpecificSong } = require("../utils");
 
 module.exports = function(
@@ -12,19 +13,21 @@ module.exports = function(
     const isDryRun = !!message.match[1];
     const track = message.match[2].trim();
     const artist = message.match[3].trim();
-    const locationName = message.match[4];
 
-    actOnSpecificSong(
-      library,
-      locations,
-      displaySongChoice,
-      action,
-      isDryRun,
-      track,
-      artist,
-      locationName,
-      bot,
-      message
-    );
+    _.forEach(locations, function(location) {
+      const locationName = location.name;
+      actOnSpecificSong(
+        library,
+        locations,
+        displaySongChoice,
+        action,
+        isDryRun,
+        track,
+        artist,
+        locationName,
+        bot,
+        message
+      );
+    });
   });
 };

--- a/src/commands/multi-location-spotify-song/index.js
+++ b/src/commands/multi-location-spotify-song/index.js
@@ -1,0 +1,31 @@
+const _ = require("lodash");
+const { actOnSpotifySong } = require("../utils");
+
+module.exports = function(
+  listen,
+  library,
+  locations,
+  displaySongChoice,
+  spotifySong,
+  action
+) {
+  listen(spotifySong, function(bot, message) {
+    const isDryRun = !!message.match[1];
+    const spotifyTrackId = message.match[2].trim();
+
+    _.forEach(locations, function(location) {
+      const locationName = location.name;
+      actOnSpotifySong(
+        library,
+        locations,
+        displaySongChoice,
+        action,
+        isDryRun,
+        spotifyTrackId,
+        locationName,
+        bot,
+        message
+      );
+    });
+  });
+};

--- a/src/commands/multi-location-wildcard-song/index.js
+++ b/src/commands/multi-location-wildcard-song/index.js
@@ -1,0 +1,31 @@
+const _ = require("lodash");
+const { actOnWildcardSong } = require("../utils");
+
+module.exports = function(
+  listen,
+  library,
+  locations,
+  displaySongChoice,
+  wildcardSong,
+  action
+) {
+  listen(wildcardSong, function(bot, message) {
+    const isDryRun = !!message.match[1];
+    const query = message.match[2].trim();
+
+    _.forEach(locations, function(location) {
+      const locationName = location.name;
+      actOnWildcardSong(
+        library,
+        locations,
+        displaySongChoice,
+        action,
+        isDryRun,
+        query,
+        locationName,
+        bot,
+        message
+      );
+    });
+  });
+};

--- a/src/commands/setup-spotify-song/index.js
+++ b/src/commands/setup-spotify-song/index.js
@@ -1,7 +1,4 @@
-const util = require("util");
-const _ = require("lodash");
-const { outputError } = require("@shopkeep/bot-scripts/utils");
-const { callWithRetry, noLocationFound } = require("../utils");
+const { actOnSpotifySong } = require("../utils");
 
 module.exports = function(
   listen,
@@ -15,61 +12,16 @@ module.exports = function(
     const isDryRun = !!message.match[1];
     const spotifyTrackId = message.match[2].trim();
     const locationName = message.match[3];
-    const pending = `:thinking_face: Searching for Spotify track \`${spotifyTrackId}\`...`;
 
-    bot.replyAndUpdate(message, pending, async function(replyErr, src, update) {
-      const updateMessage = util.promisify(update);
-
-      if (replyErr) {
-        outputError(bot, message, replyErr);
-        return;
-      }
-
-      const location = await locations.getLocation(bot, message, locationName);
-      if (
-        await noLocationFound(message, updateMessage, location, locationName)
-      ) {
-        return;
-      }
-
-      let songs = null;
-      try {
-        songs = await callWithRetry(() =>
-          library.getSongs(location, [spotifyTrackId])
-        );
-      } catch (libraryErr) {
-        outputError(bot, message, libraryErr);
-        return;
-      }
-
-      if (!_.isArray(songs) || songs.length === 0) {
-        await updateMessage(
-          `Sorry <@${message.user}>, ` +
-            `I wasn't able to find a Spotify track matching \`${spotifyTrackId}\`. ` +
-            "Please try another search, or `I'm feeling lucky` if you can't decide!"
-        );
-        return;
-      }
-
-      const song = _.first(songs);
-
-      try {
-        if (!isDryRun) {
-          await callWithRetry(() => location.player[action](song));
-        }
-      } catch (playerErr) {
-        outputError(bot, message, playerErr);
-        return;
-      }
-
-      displaySongChoice(
-        bot,
-        updateMessage,
-        message,
-        song,
-        isDryRun,
-        location.name
-      );
-    });
+    actOnSpotifySong(
+      library,
+      locations,
+      displaySongChoice,
+      action,
+      isDryRun,
+      spotifyTrackId,
+      locationName,
+      message
+    );
   });
 };

--- a/src/commands/setup-wildcard-song/index.js
+++ b/src/commands/setup-wildcard-song/index.js
@@ -1,7 +1,4 @@
-const util = require("util");
-const _ = require("lodash");
-const { outputError } = require("@shopkeep/bot-scripts/utils");
-const { callWithRetry, noLocationFound } = require("../utils");
+const { actOnWildcardSong } = require("../utils");
 
 module.exports = function(
   listen,
@@ -15,57 +12,17 @@ module.exports = function(
     const isDryRun = !!message.match[1];
     const query = message.match[2].trim();
     const locationName = message.match[3];
-    const pending = `:thinking_face: Searching for \`${query}\`...`;
 
-    bot.replyAndUpdate(message, pending, async function(replyErr, src, update) {
-      const updateMessage = util.promisify(update);
-
-      if (replyErr) {
-        outputError(bot, message, replyErr);
-        return;
-      }
-
-      const location = await locations.getLocation(bot, message, locationName);
-      if (
-        await noLocationFound(message, updateMessage, location, locationName)
-      ) {
-        return;
-      }
-
-      let song = null;
-      try {
-        song = await callWithRetry(() => library.blindSearch(location, query));
-      } catch (libraryErr) {
-        outputError(bot, message, libraryErr);
-        return;
-      }
-
-      if (_.isNull(song)) {
-        await updateMessage(
-          `Sorry <@${message.user}>, ` +
-            `I wasn't able to find anything matching \`${query}\`. ` +
-            "Please try another search, or `I'm feeling lucky` if you can't decide!"
-        );
-        return;
-      }
-
-      try {
-        if (!isDryRun) {
-          await callWithRetry(() => location.player[action](song));
-        }
-      } catch (playerErr) {
-        outputError(bot, message, playerErr);
-        return;
-      }
-
-      displaySongChoice(
-        bot,
-        updateMessage,
-        message,
-        song,
-        isDryRun,
-        location.name
-      );
-    });
+    actOnWildcardSong(
+      library,
+      locations,
+      displaySongChoice,
+      action,
+      isDryRun,
+      query,
+      locationName,
+      bot,
+      message
+    );
   });
 };

--- a/src/commands/utils/act-on-specific-song.js
+++ b/src/commands/utils/act-on-specific-song.js
@@ -1,0 +1,72 @@
+const util = require("util");
+const _ = require("lodash");
+const { outputError } = require("@shopkeep/bot-scripts/utils");
+const { callWithRetry, noLocationFound } = require("../utils");
+
+const actOnSpecificSong = function(
+  library,
+  locations,
+  displaySongChoice,
+  action,
+  isDryRun,
+  track,
+  artist,
+  locationName,
+  bot,
+  message
+) {
+  const pending = `:thinking_face: Searching for \`${track}\` by \`${artist}\`...`;
+
+  bot.replyAndUpdate(message, pending, async function(replyErr, src, update) {
+    const updateMessage = util.promisify(update);
+
+    if (replyErr) {
+      outputError(bot, message, replyErr);
+      return;
+    }
+
+    const location = await locations.getLocation(bot, message, locationName);
+    if (await noLocationFound(message, updateMessage, location, locationName)) {
+      return;
+    }
+
+    let song = null;
+    try {
+      song = await callWithRetry(() =>
+        library.songSearch(location, artist, track)
+      );
+    } catch (libraryErr) {
+      outputError(bot, message, libraryErr);
+      return;
+    }
+
+    if (_.isNull(song)) {
+      await updateMessage(
+        `Sorry <@${message.user}>, ` +
+          `I wasn't able to find anything matching \`${track}\` by \`${artist}\`. ` +
+          "Please try another search, or `I'm feeling lucky` if you can't decide!"
+      );
+      return;
+    }
+
+    try {
+      if (!isDryRun) {
+        await callWithRetry(() => location.player[action](song));
+      }
+    } catch (playerErr) {
+      outputError(bot, message, playerErr);
+      return;
+    }
+
+    displaySongChoice(
+      bot,
+      updateMessage,
+      message,
+      song,
+      isDryRun,
+      location.name
+    );
+  });
+};
+
+module.exports = actOnSpecificSong;

--- a/src/commands/utils/act-on-spotify-song.js
+++ b/src/commands/utils/act-on-spotify-song.js
@@ -1,0 +1,73 @@
+const util = require("util");
+const _ = require("lodash");
+const { outputError } = require("@shopkeep/bot-scripts/utils");
+const { callWithRetry, noLocationFound } = require("../utils");
+
+const actOnSpotifySong = function(
+  library,
+  locations,
+  displaySongChoice,
+  action,
+  isDryRun,
+  spotifyTrackId,
+  locationName,
+  bot,
+  message
+) {
+  const pending = `:thinking_face: Searching for Spotify track \`${spotifyTrackId}\`...`;
+
+  bot.replyAndUpdate(message, pending, async function(replyErr, src, update) {
+    const updateMessage = util.promisify(update);
+
+    if (replyErr) {
+      outputError(bot, message, replyErr);
+      return;
+    }
+
+    const location = await locations.getLocation(bot, message, locationName);
+    if (await noLocationFound(message, updateMessage, location, locationName)) {
+      return;
+    }
+
+    let songs = null;
+    try {
+      songs = await callWithRetry(() =>
+        library.getSongs(location, [spotifyTrackId])
+      );
+    } catch (libraryErr) {
+      outputError(bot, message, libraryErr);
+      return;
+    }
+
+    if (!_.isArray(songs) || songs.length === 0) {
+      await updateMessage(
+        `Sorry <@${message.user}>, ` +
+          `I wasn't able to find a Spotify track matching \`${spotifyTrackId}\`. ` +
+          "Please try another search, or `I'm feeling lucky` if you can't decide!"
+      );
+      return;
+    }
+
+    const song = _.first(songs);
+
+    try {
+      if (!isDryRun) {
+        await callWithRetry(() => location.player[action](song));
+      }
+    } catch (playerErr) {
+      outputError(bot, message, playerErr);
+      return;
+    }
+
+    displaySongChoice(
+      bot,
+      updateMessage,
+      message,
+      song,
+      isDryRun,
+      location.name
+    );
+  });
+};
+
+module.exports = actOnSpotifySong;

--- a/src/commands/utils/act-on-wildcard-song.js
+++ b/src/commands/utils/act-on-wildcard-song.js
@@ -1,0 +1,69 @@
+const util = require("util");
+const _ = require("lodash");
+const { outputError } = require("@shopkeep/bot-scripts/utils");
+const { callWithRetry, noLocationFound } = require("../utils");
+
+const actOnWildcardSong = function(
+  library,
+  locations,
+  displaySongChoice,
+  action,
+  isDryRun,
+  query,
+  locationName,
+  bot,
+  message
+) {
+  const pending = `:thinking_face: Searching for \`${query}\`...`;
+
+  bot.replyAndUpdate(message, pending, async function(replyErr, src, update) {
+    const updateMessage = util.promisify(update);
+
+    if (replyErr) {
+      outputError(bot, message, replyErr);
+      return;
+    }
+
+    const location = await locations.getLocation(bot, message, locationName);
+    if (await noLocationFound(message, updateMessage, location, locationName)) {
+      return;
+    }
+
+    let song = null;
+    try {
+      song = await callWithRetry(() => library.blindSearch(location, query));
+    } catch (libraryErr) {
+      outputError(bot, message, libraryErr);
+      return;
+    }
+
+    if (_.isNull(song)) {
+      await updateMessage(
+        `Sorry <@${message.user}>, ` +
+          `I wasn't able to find anything matching \`${query}\`. ` +
+          "Please try another search, or `I'm feeling lucky` if you can't decide!"
+      );
+      return;
+    }
+
+    try {
+      if (!isDryRun) {
+        await callWithRetry(() => location.player[action](song));
+      }
+    } catch (playerErr) {
+      outputError(bot, message, playerErr);
+      return;
+    }
+
+    displaySongChoice(
+      bot,
+      updateMessage,
+      message,
+      song,
+      isDryRun,
+      location.name
+    );
+  });
+};
+
+module.exports = actOnWildcardSong;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ const customEmojis = {
   "queue `song title` by `artist`": ":woman-with-bunny-ears-partying:",
   "queue `song title or artist`": ":man-with-bunny-ears-partying:",
   "queue `spotify:track:spotify-track-uuid`": ":dancers:",
+  "broadcast `song title` by `artist`": ":loudspeaker:",
+  "broadcast `song title or artist`": ":loud_sound:",
+  "broadcast `spotify:track:spotify-track-uuid`": ":speaker:",
   pause: ":double_vertical_bar:",
   "show playing": ":speaking_head_in_silhouette:",
   "show queue": ":bouquet:"


### PR DESCRIPTION
A little refactor separating execution of specific tasks from regex parsing of said tasks.

Adds a `deploy-choon` command to send that tune *EVERYWHERE*